### PR TITLE
Really stop interval on response finish

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,9 +15,12 @@ function sseMiddleware(__, res, next) {
     'Access-Control-Allow-Origin': '*'
   });
 
-  setInterval(() => {
+  const handshakeInterval = setInterval(() => {
     res.write(': sse-handshake');
   }, 3000);
+  res.on('end', () => {
+    clearInterval(handshakeInterval);
+  });
 
   /**
    * Add function to response which allow to send events to the client

--- a/index.js
+++ b/index.js
@@ -18,9 +18,9 @@ function sseMiddleware(__, res, next) {
   const handshakeInterval = setInterval(() => {
     res.write(': sse-handshake');
   }, 3000);
-  res.on('end', () => {
-    clearInterval(handshakeInterval);
-  });
+
+  res.on('finish', () => clearInterval(handshakeInterval));
+  res.on('close', () => clearInterval(handshakeInterval));
 
   /**
    * Add function to response which allow to send events to the client


### PR DESCRIPTION
Since the "end" event wasn't working for me, I have google it, and it seems the finish event, is the one node always emits from the **OutgoingMessage** Object.

https://github.com/nodejs/node/blob/master/lib/_http_outgoing.js#L735

