### PR TITLE
make event-name optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,9 +31,10 @@ function sseMiddleware(__, res, next) {
     if (id) {
       res.write(`id: ${id}\n`);
     }
-
+    if (evt) {
+      res.write(`event: ${evt}\n`);
+    }
     res.write(`retry: 3000\n`);
-    res.write(`event: ${evt}\n`);
     res.write(`data: ${JSON.stringify(json)}\n\n`);
   };
   next();


### PR DESCRIPTION
If I have understood correctly, the server could ommit the "event: EventName" field, so the browser would use the default name "message".