### PR TITLE
Add `lastEventId` property to `sse` field in Request object

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ app.get('/updates', sseExpress(), function(req, res) {
       welcomeMsg: 'Hello world!'
     });
 });
-```
+`````````
 
 At the client side you can listen to message through `EventSource` instance:
 
@@ -74,5 +74,11 @@ The priority of choosing which option to be used is (from low to high priority):
 `evt` - is event name
 `json` - object that will be sent as json string to a client
 `[id]` - optional id of event
+
+#### res.sse.lastEventId
+Property which contains either `Last-Event-Id` header or `lastEventId` query parameter. Normally it's sent by browser in request headers. 
+But not all (almost all) browsers do such. That's why middleware also can read query parameter `lastEventId`. 
+
+Every time `res.sse` called with not empty `id` parameter `res.sse.lastEventId` will be replaced with this value. 
 
 ## [MIT License](http://likerrr.mit-license.org/)

--- a/example/sse-chat/client.html
+++ b/example/sse-chat/client.html
@@ -41,7 +41,7 @@
 
   function listenUpdates() {
     // subscribe to updates
-    eventSource = new EventSource('http://localhost:99/updates?handshake-interval=3000');
+    eventSource = new EventSource('http://localhost:99/updates?handshake-interval=3000&lastEventId=2376523');
 
     eventSource.addEventListener('message', onMessage);
     eventSource.addEventListener('connected', onConnected);

--- a/example/sse-chat/server.js
+++ b/example/sse-chat/server.js
@@ -30,7 +30,7 @@
       connection.sse('message', {
         text: req.body.message,
         userId: req.body.userId
-      });
+      }, Date.now() + req.body.userId);
     });
 
     res.end();


### PR DESCRIPTION
Since not all browsers send `Last-Event-Id` header, middleware set up to
handle both `Last-Event-Id` (case insensitive) header and `lastEventId`
query parameter

Closes #6 