### PR TITLE
Terminate handshakes

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,7 +133,7 @@ function keepAlive(res) {
  * @param updateInterval
  */
 function setHandshakeInterval(res, updateInterval) {
-  const handshakeInterval = setInterval(() => res.write(': sse-handshake'), updateInterval);
+  const handshakeInterval = setInterval(() => res.write(': sse-handshake\n'), updateInterval);
 
   res.on('finish', () => clearInterval(handshakeInterval));
   res.on('close', () => clearInterval(handshakeInterval));


### PR DESCRIPTION
This does two things:

1. By virtue of Express' default line buffering for responses, it causes the `: sse-handshake` message to go out promptly rather than being buffered in memory.
2. It ensures that multiple handshakes aren't stacked up on a single line, and don't interfere with the next payload.

I ran into this after leaving a connection idle for a while:

```
: sse-handshake: sse-handshake: sse-handshakeretry: 3000
id: 3389
event: event
data: {}
```